### PR TITLE
Update to debug 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-nightwatch",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "simple, flexible, fun test framework",
   "keywords": [
     "mocha",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "commander": "2.3.0",
-    "debug": "2.0.0",
+    "debug": "2.2.0",
     "diff": "1.4.0",
     "escape-string-regexp": "1.0.2",
     "glob": "3.2.3",


### PR DESCRIPTION
[This vulnerability in ms](https://nodesecurity.io/advisories/46) was patched in versions >0.7.0
The v2.2.0 of the debug library uses v0.7.1 of ms
Accordingly this PR updates the project to v2.2.0 of debug